### PR TITLE
Update to: Compatibility Updates for Python 2.7.12

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,11 @@
+2017-02-27  Ray Brown  <code@liquibits.com>
+
+	* dtls/openssl.py: support reading directly into given buffer instead of forcing buffer copy (for ssl module compatibility)
+	* dtls/sslconnection.py: in-situ receive support, as above
+	* dtls/patch.py: various changes for compatibility with the ssl module of Python 2.7.12; note that the ssl module's new SSLContext is not supported
+	* dtls/test/unit.py: changes to support the updated ssl module, including fix of deprecation warnings
+	* setup.py: increase version to 1.0.2
+
 2014-01-18  Ray Brown  <code@liquibits.com>
 
 	* setup.py: Increase version to 1.0.1 for release to PyPI

--- a/dtls/err.py
+++ b/dtls/err.py
@@ -96,8 +96,8 @@ def raise_ssl_error(code, nested=None):
     """Raise an SSL error with the given error code"""
     err_string = str(code) + ": " + _ssl_errors[code]
     if nested:
-        raise SSLError(err_string, nested)
-    raise SSLError(err_string)
+        raise SSLError(code, err_string + str(nested))
+    raise SSLError(code, err_string)
 
 _ssl_errors = {
     ERR_NO_CERTS: "No root certificates specified for verification " + \

--- a/dtls/openssl.py
+++ b/dtls/openssl.py
@@ -735,9 +735,15 @@ def DTLSv1_listen(ssl):
     errcheck_ord(ret, _SSL_ctrl, (ssl, DTLS_CTRL_LISTEN, 0, byref(su)))
     return addr_tuple_from_sockaddr_u(su)
 
-def SSL_read(ssl, length):
-    buf = create_string_buffer(length)
-    res_len = _SSL_read(ssl, buf, sizeof(buf))
+def SSL_read(ssl, length, buffer):
+    if buffer:
+        length = min(length, len(buffer))
+        buf = (c_char * length).from_buffer(buffer)
+    else:
+        buf = create_string_buffer(length)
+    res_len = _SSL_read(ssl, buf, length)
+    if buffer:
+        return res_len
     return buf.raw[:res_len]
 
 def SSL_write(ssl, data):

--- a/dtls/sslconnection.py
+++ b/dtls/sslconnection.py
@@ -514,7 +514,7 @@ class SSLConnection(object):
         self._handshake_done = True
         _logger.debug("...completed handshake")
 
-    def read(self, len=1024):
+    def read(self, len=1024, buffer=None):
         """Read data from connection
 
         Read up to len bytes and return them.
@@ -526,7 +526,7 @@ class SSLConnection(object):
         """
 
         return self._wrap_socket_library_call(
-            lambda: SSL_read(self._ssl.value, len), ERR_READ_TIMEOUT)
+            lambda: SSL_read(self._ssl.value, len, buffer), ERR_READ_TIMEOUT)
 
     def write(self, data):
         """Write data to connection

--- a/dtls/test/unit.py
+++ b/dtls/test/unit.py
@@ -78,7 +78,6 @@ class BasicSocketTests(unittest.TestCase):
 
     def test_constants(self):
         ssl.PROTOCOL_SSLv23
-        ssl.PROTOCOL_SSLv3
         ssl.PROTOCOL_TLSv1
         ssl.PROTOCOL_DTLSv1  # added
         ssl.CERT_NONE
@@ -573,6 +572,9 @@ class AsyncoreEchoServer(threading.Thread):
                 self._ssl_accepting = True
                 # Complete the handshake
                 self.handle_read_event()
+
+            def __hash__(self):
+                return hash(self.socket)
 
             def readable(self):
                 while self.socket.pending() > 0:

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ for scheme in INSTALL_SCHEMES.values():
     scheme['data'] = scheme['purelib']
 
 NAME = "Dtls"
-VERSION = "1.0.1"
+VERSION = "1.0.2"
 
 DIST_DIR = "dist"
 FORMAT_TO_SUFFIX = { "zip": ".zip",


### PR DESCRIPTION
	* dtls/openssl.py: support reading directly into given buffer instead
                     of forcing buffer copy (for ssl module compatibility)
	* dtls/sslconnection.py: in-situ receive support, as above
	* dtls/patch.py: various changes for compatibility with the ssl module
                   of Python 2.7.12; note that the ssl module's new
                   SSLContext is not supported
	* dtls/test/unit.py: changes to support the updated ssl module,
                       including fix of deprecation warnings
	* setup.py: increase version to 1.0.2