### PR TITLE
Workaround for Windows concerning the MTU size

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,12 @@
 2017-03-28  Björn Freise  <mcfreis@gmx.net>
 
+	Workaround for Windows concerning the MTU size
+
+	* dtls/sslconnection.py: Hardcoded setting of the MTU size only for Windows and in case it is not already configured
+	* dtls/test/unit_wrapper.py: No user config of the MTU size; using the hardcoded one from SSLConnection
+
+2017-03-28  Björn Freise  <mcfreis@gmx.net>
+
 	Minor fixes and "hopefully" compatible to Ubuntu 16.04
 
 	* dtls/__init__.py: Removed wrapper import

--- a/dtls/sslconnection.py
+++ b/dtls/sslconnection.py
@@ -40,6 +40,7 @@ library's ssl module, since its values can be passed to this module.
   CERT_REQUIRED
 """
 
+import sys
 import errno
 import socket
 import hmac
@@ -560,9 +561,11 @@ class SSLConnection(object):
 
         if self._user_config_ssl:
             self._user_config_ssl(self._intf_ssl)
-        else:
+
+        if sys.platform.startswith('win') and not (SSL_get_options(self._ssl.value) & SSL_OP_NO_QUERY_MTU):
             SSL_set_options(self._ssl.value, SSL_OP_NO_QUERY_MTU)
             DTLS_set_link_mtu(self._ssl.value, 1500)
+
         SSL_set_bio(self._ssl.value, self._rbio.value, self._wbio.value)
         self._rbio.disown()
         self._wbio.disown()

--- a/dtls/test/unit_wrapper.py
+++ b/dtls/test/unit_wrapper.py
@@ -378,7 +378,7 @@ def params_test(start_server, certfile, protocol, certreqs, cacertsfile,
                 client_certfile=None, client_protocol=None, client_certreqs=None, client_cacertsfile=None,
                 ciphers=None, curves=None, sigalgs=None,
                 client_ciphers=None, client_curves=None, client_sigalgs=None,
-                mtu=1500, server_key_exchange_curve=None, server_cert_options=None,
+                mtu=None, server_key_exchange_curve=None, server_cert_options=None,
                 indata="FOO\n", chatty=False, connectionchatty=False):
     """
     Launch a server, connect a client to it and try various reads
@@ -508,7 +508,7 @@ class WrapperTests(unittest.TestCase):
                                         ciphers=None,
                                         curves=None,
                                         sigalgs=None,
-                                        mtu=1500,
+                                        mtu=None,
                                         server_key_exchange_curve=None,
                                         server_cert_options=step,
                                         chatty=chatty)
@@ -526,7 +526,7 @@ class WrapperTests(unittest.TestCase):
                                ciphers=None,
                                curves=None,
                                sigalgs=None,
-                               user_mtu=1500)
+                               user_mtu=None)
                 s.connect((HOST, server.port))
                 if connectionchatty:
                     sys.stdout.write(" client:  sending %s...\n" % (repr(indata)))
@@ -595,7 +595,7 @@ class WrapperTests(unittest.TestCase):
                                         ciphers=None,
                                         curves=None,
                                         sigalgs=None,
-                                        mtu=1500,
+                                        mtu=None,
                                         server_key_exchange_curve=server_curve,
                                         server_cert_options=None,
                                         chatty=chatty)
@@ -613,7 +613,7 @@ class WrapperTests(unittest.TestCase):
                                ciphers=None,
                                curves=client_curve,
                                sigalgs=None,
-                               user_mtu=1500)
+                               user_mtu=None)
                 s.connect((HOST, server.port))
                 if connectionchatty:
                     sys.stdout.write(" client:  sending %s...\n" % (repr(indata)))


### PR DESCRIPTION
* dtls/sslconnection.py: Hardcoded setting of the MTU size only for Windows and in case it is not already configured
* dtls/test/unit_wrapper.py: No user config of the MTU size; using the hardcoded one from SSLConnection 

@rbit Could that be the solution?